### PR TITLE
add intellij folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,7 @@ Temporary Items
 !.vscode/extensions.json
 *.code-workspace
 
+### intellij ###
+.idea
+
 # End of https://www.toptal.com/developers/gitignore/api/vscode,osx


### PR DESCRIPTION
When using JetBrains products like WebStorm ect. it is handy to have this folder ignored