### PR TITLE
add permissions for smart building

### DIFF
--- a/SmartBuilding/Building/doc/spec.md
+++ b/SmartBuilding/Building/doc/spec.md
@@ -1,7 +1,10 @@
 # Building
 
 The data model is based on [Smart data model Building](https://github.com/smart-data-models/dataModel.Building)
-It contains the following addtional properties:
+It contains the following additional properties:
+
+Permission may be requested using the [Permission data model](https://github.com/inspire-datamodel/SmartBuilding/Permission/docs/spec.md) at any given time to gain extended access after smarthome owner approval.
 
 ## Data model
 - `floorPlan`: Text. Url to a floor plan (e.g. a PDF or image)
+- `permission`: StructuredValue. See [Permission data model](https://github.com/inspire-datamodel/SmartBuilding/Permission/docs/spec.md) for value details.

--- a/SmartBuilding/Building/examples/building.json
+++ b/SmartBuilding/Building/examples/building.json
@@ -32,5 +32,11 @@
     },
     "floorPlan": {
         "value:": "https://storage.inspireprojekt.de/smarthome/"
+    },
+    "permissions":  {
+        "type": "Permission",
+        "value": {
+            "*": "READ"
+        }
     }
 }

--- a/SmartBuilding/Device/doc/spec.md
+++ b/SmartBuilding/Device/doc/spec.md
@@ -41,8 +41,15 @@ The data model is adapted from [Smart data model Device](https://github.com/smar
 
 - `deviceState`: Enum. One of `OK`, `WARNING`, `ALARM`, `ERROR`
 - `action`: Only if category is actuator
-  - `status`: `PENDING`, `SUCCESS`, `DENIED`, `ERROR`, `TIMEOUT`
+  - `status`: 
+    - `PENDING`: The new value is being written to the device
+    - `SUCCESS`: The new value was applied successfully
+    - `DENIED`: The new value was rejected due to insufficient permissions
+    - `ERROR`: The new value could not be written due to a device error
+    - `TIMEOUT`: The new value could not be written due to a device timeout
+    - `WAITING`: The new value will be written after smarthome owner approval
   - `desiredValue`: see value
+
 
 
 - `value`: current status, number, Text (depends on the controlledProperty)

--- a/SmartBuilding/Permission/docs/spec.md
+++ b/SmartBuilding/Permission/docs/spec.md
@@ -1,0 +1,16 @@
+# Permission
+
+
+
+## Data model
+
+- `id`: Unique identifier
+
+- `type`: Device
+
+- `attachedTo`: Relationship. ID of the Building to which this Device is attached to
+
+- `permission`: StructuredValue. Explanation of permissions: `LIST` will give access to available devices (name, position, ...) without the current status. `READ` extends the `LIST` permission by the current status. `WRITE` extends the `READ` permission by allowing to set a new value.
+  - `*`: Text. Permissions for actuator, sensor and future devices types. One of `LIST`, `READ`, `WRITE`. Allows to define the base permission. Any specific permission specification like `actuator` or `sensor` will take precedence. Defining `WRITE` will still just give `READ` permissions for `sensor`.
+  - `actuator`: Text. Permissions for actuator. One of `LIST`, `READ`, `WRITE`. Do not define `actuator` if no specific permission should be given.
+  - `sensor`: Text. Permissions for sensor. One of `LIST`, `READ`. Do not define `sensor` if no specific permission should be given.

--- a/SmartBuilding/Permission/examples/Permission.json
+++ b/SmartBuilding/Permission/examples/Permission.json
@@ -1,0 +1,20 @@
+{
+    "id": "urn:ngsi-ld:Device:Sensor51433",
+    "type": "Device",
+    "attachedTo": {
+        "type": "StructuredValue",
+        "value": {
+            "attachedToType": "Building",
+            "attachedToId": "urn:ngsi-ld:Building:89c27488-f934-427e-eff9-988ef3dd0da3"
+        },
+        "metadata": {}
+    },
+    "request": {
+        "type": "Permission",
+        "value": {
+            "*": "LIST",
+            "sensor": "READ",
+            "actuator": "WRITE"
+        }
+    }
+}

--- a/SmartBuilding/Subscription/docs/spec.md
+++ b/SmartBuilding/Subscription/docs/spec.md
@@ -1,0 +1,9 @@
+# Subscription
+
+The event data model will be used to push events like action requests to devices over a WebSocket channel
+
+## Data model
+
+- `subscriptionId`: Unique identifier
+
+- `data`: Array of [Device](https://github.com/inspire-datamodel/SmartBuilding/Devce/docs/spec.md) containing the newly requested action on the device.

--- a/SmartBuilding/Subscription/examples/Subscription.json
+++ b/SmartBuilding/Subscription/examples/Subscription.json
@@ -1,0 +1,36 @@
+{
+  "subscriptionId": "607e7df77c25e580a94d3fa1",
+  "data": [
+    {
+      "id": "urn:ngsi-ld:Device:Actuator1234",
+      "type": "Device",
+      "action": {
+        "desiredValue": "CLOSE",
+        "status": "PENDING"
+      },
+      "attachedTo": {
+        "attachedToType": "Building",
+        "attachedToId": "urn:ngsi-ld:Building:660635b2-eac7-464d-41d9-5d9820daaefb"
+      },
+      "category": [
+        "actuator"
+      ],
+      "controlledProperty": [
+        "door"
+      ],
+      "dateLastValueReported": "2021-04-19T15:31:32.000Z",
+      "description": "Test Actuator1234",
+      "deviceState": "OK",
+      "location": {
+        "type": "Point",
+        "coordinates": [
+          10.7485,
+          54.0508
+        ]
+      },
+      "name": "Haustür Test",
+      "source": "Test",
+      "value": "OPEN"
+    }
+  ]
+}


### PR DESCRIPTION
As previously discussed we wanted to extend the permissions to the Device and Building data models. This is a first draft on how this could look like. Things we might want to consider:

 * Time limitation for permission requests (normally a few hours are probably sufficient but give comfort that the granted permissions are not permanent)
 * Permissions can only be extended at this time due to a simple text value. A combination of `LIST`+ `WRITE` but not `READ` is not possible. Anyway i couldn't think of a use-case that this would be useful.
 * Docs for subscriptions are incomplete. As far as i remembers data can hold various data models. I am at least remembering the "Warning" model we used for our first exercise. @Siedlerchr Can you add the models that may be sent? Maybe we should move subscriptions out of smart building to the top-level?
 
The permission workflow has three possibilities:
 1. The smarthome owner granted permissions in advance. Nothing special needs to be taken care of. (Everything works as is)
 2. The smarthome ower did not grant any permissions. We will request a specific subset of permissions for *, sensor and/or actuator which will allow us to see and control devices after approval. No further approval will be required afterwards (until an optional timeout expires)
 3. The smarthome owner only granted `LIST` or `READ` permission in advance or we only requested `LIST` or `READ` permissions (See 2). When sending a control request to a device the smarthome owner will need to approve it for each request.